### PR TITLE
Add light mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,11 @@
           <li><a href="#projects" class="text-gray-100 hover:text-[#1DCD9F] transition">Projects</a></li>
           <li><a href="#upcoming-projects" class="text-gray-100 hover:text-[#1DCD9F] transition">Upcoming</a></li>
           <li><a href="#contact" class="text-gray-100 hover:text-[#1DCD9F] transition">Contact</a></li>
+          <li>
+            <button id="theme-toggle" class="text-gray-100 hover:text-[#1DCD9F] transition bg-transparent border-0">
+              <i id="theme-icon" class="fas fa-sun"></i>
+            </button>
+          </li>
         </ul>
       </nav>
     </header>

--- a/script.js
+++ b/script.js
@@ -278,4 +278,31 @@ gsap.from(".project-card", {
       delay: i * 0.15,
     });
   });
+
+// Theme toggle logic
+function setTheme(light) {
+  const body = document.body;
+  const icon = document.getElementById('theme-icon');
+  if (light) {
+    body.classList.add('light-mode');
+    icon.classList.remove('fa-sun');
+    icon.classList.add('fa-moon');
+    localStorage.setItem('theme', 'light');
+  } else {
+    body.classList.remove('light-mode');
+    icon.classList.remove('fa-moon');
+    icon.classList.add('fa-sun');
+    localStorage.setItem('theme', 'dark');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const stored = localStorage.getItem('theme');
+  setTheme(stored === 'light');
+  const toggle = document.getElementById('theme-toggle');
+  toggle.addEventListener('click', () => {
+    const isLight = document.body.classList.contains('light-mode');
+    setTheme(!isLight);
+  });
+});
   

--- a/styles.css
+++ b/styles.css
@@ -6,22 +6,29 @@
     padding: 0;
     box-sizing: border-box;
   }
-  body {
-    font-family: "Special Gothic Expanded One", sans-serif; 
-    background-color: #000;
-    color: #fff;
-    overflow: -moz-scrollbars-none; /* For Firefox */
+:root {
+  --bg-color: #000;
+  --text-color: #fff;
+  --link-color: #fff;
+  --header-bg: #000;
+}
+
+body {
+  font-family: "Special Gothic Expanded One", sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  overflow: -moz-scrollbars-none; /* For Firefox */
   -ms-overflow-style: none; /* For Internet Explorer 10+ */
   scrollbar-width: none; /* For Firefox */
-    /* scroll-behavior: smooth; */
-  }
+  /* scroll-behavior: smooth; */
+}
   
   body::-webkit-scrollbar {
     display: none; /* For Chrome, Safari, and Opera */
   }
   a {
     text-decoration: none;
-    color: white;
+    color: var(--link-color);
   }
   
   /* Loading screen */
@@ -293,6 +300,31 @@
 
     color: white;
   }
+
+/* Light mode overrides */
+body.light-mode {
+  --bg-color: #fff;
+  --text-color: #000;
+  --link-color: #000;
+  --header-bg: #fff;
+}
+
+body.light-mode .bg-black {
+  background-color: #fff !important;
+}
+
+body.light-mode .text-white {
+  color: #000 !important;
+}
+
+body.light-mode header {
+  background-color: var(--header-bg) !important;
+}
+
+body.light-mode #loading {
+  background: #fff;
+}
+
 
 
   


### PR DESCRIPTION
## Summary
- add light mode toggle button in header
- support light mode styles
- persist selected theme via localStorage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852480474488329b245941b071ef4ac